### PR TITLE
Remove manual GC invocation

### DIFF
--- a/BackgroundServices/AutoUserDownload.cs
+++ b/BackgroundServices/AutoUserDownload.cs
@@ -72,29 +72,5 @@ class AutoUserDownload : BackgroundService {
         }
 
         if (processed > 10) Log($"Member list downloads handled for {processed} guilds.");
-        ConsiderGC(processed);
     }
-
-    #region Manual garbage collection
-    private static readonly object _mgcTrackLock = new();
-    private static int _mgcProcessedSinceLast = 0;
-
-    // Downloading user information adds up memory-wise, particularly within the
-    // Gen 2 collection. Here we attempt to balance not calling the GC too much
-    // while also avoiding dying to otherwise inevitable excessive memory use.
-    private static void ConsiderGC(int processed) {
-        const int CallGcAfterProcessingAmt = 1500;
-        bool trigger;
-        lock (_mgcTrackLock) {
-            _mgcProcessedSinceLast += processed;
-            trigger = _mgcProcessedSinceLast > CallGcAfterProcessingAmt;
-            if (trigger) _mgcProcessedSinceLast = 0;
-        }
-        if (trigger) {
-            Program.Log(nameof(AutoUserDownload), "Invoking garbage collection...");
-            GC.Collect(2, GCCollectionMode.Forced, true, true);
-            Program.Log(nameof(AutoUserDownload), "Complete.");
-        }
-    }
-    #endregion
 }

--- a/ShardManager.cs
+++ b/ShardManager.cs
@@ -118,8 +118,10 @@ class ShardManager : IDisposable {
 
                     var shard = _shards[i]!;
                     var client = shard.DiscordClient;
+                    // TODO look into better connection checking options. ConnectionState is not reliable.
                     shardStatuses.Append($"{Enum.GetName(typeof(ConnectionState), client.ConnectionState)} ({client.Latency:000}ms).");
-                    shardStatuses.Append($" Guilds: {client.Guilds.Count}.");
+                    shardStatuses.Append($" Guilds: {client.Guilds.Count:0000}.");
+                    shardStatuses.Append($" Users: {client.Guilds.Sum(s => s.Users.Count):000000}.");
                     shardStatuses.Append($" Background: {shard.CurrentExecutingService ?? "Idle"}");
                     var lastRun = DateTimeOffset.UtcNow - shard.LastBackgroundRun;
                     if (lastRun > DeadShardThreshold / 3) {
@@ -146,6 +148,7 @@ class ShardManager : IDisposable {
 
                 // Start null shards, a few at at time
                 var startAllowance = Config.MaxConcurrentOperations;
+
                 foreach (var id in nullShards) {
                     if (startAllowance-- > 0) {
                         _shards[id] = await InitializeShard(id);


### PR DESCRIPTION
The public instance has lately been pushing up against its memory limits on the server, causing a fair bit of instability as a set of shards is taken by the OOM Killer and made unavailable for a random set of users.
Further investigation revealed that frequent calls for garbage collection result in the host OS unable to recognize memory that can be swapped out. This eliminates out-of-memory errors, in addition to adhering to the common-sense practice of not manually invoking garbage collection.

Additionally, added a user count to the per-shard status display in order to better understand which particular shards may require extra resources.